### PR TITLE
Linux Build + Side Panel Dark Mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,10 +46,10 @@ jobs:
         with:
           name: app
           path: |
-            Hdl21SchematicEditor/packages/EditorApp/out/*/*.app
-            Hdl21SchematicEditor/packages/EditorApp/out/*/*.exe
-            Hdl21SchematicEditor/packages/EditorApp/out/*/*.deb
-            Hdl21SchematicEditor/packages/EditorApp/out/*/*.rpm
+            Hdl21SchematicEditor/packages/EditorApp/out/make/*/*/*.app
+            Hdl21SchematicEditor/packages/EditorApp/out/make/*/*/*.exe
+            Hdl21SchematicEditor/packages/EditorApp/out/make/*/*/*.deb
+            Hdl21SchematicEditor/packages/EditorApp/out/make/*/*/*.rpm
 
   python_importer_tests:
     name: Python Importer Test Suite

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,8 +48,8 @@ jobs:
           path: |
             Hdl21SchematicEditor/packages/EditorApp/out/*/*.app
             Hdl21SchematicEditor/packages/EditorApp/out/*/*.exe
-    continue-on-error: ${{ matrix.os == 'ubuntu-latest' }}
-    # FIXME: haven't sorted this out on Linux, yet
+            Hdl21SchematicEditor/packages/EditorApp/out/*/*.deb
+            Hdl21SchematicEditor/packages/EditorApp/out/*/*.rpm
 
   python_importer_tests:
     name: Python Importer Test Suite

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           name: app
           path: |
-            Hdl21SchematicEditor/packages/EditorApp/out/make/*/*/*.app
+            Hdl21SchematicEditor/packages/EditorApp/out/*/*.app
             Hdl21SchematicEditor/packages/EditorApp/out/make/*/*/*.exe
             Hdl21SchematicEditor/packages/EditorApp/out/make/*/*/*.deb
             Hdl21SchematicEditor/packages/EditorApp/out/make/*/*/*.rpm

--- a/Hdl21SchematicEditor/packages/EditorApp/package.json
+++ b/Hdl21SchematicEditor/packages/EditorApp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hdl21-schematic-editor-app",
+  "name": "Hdl21SchematicEditor",
   "private": true,
   "version": "1.0.0",
   "productName": "Hdl21SchematicEditor",

--- a/Hdl21SchematicEditor/packages/EditorCore/src/panels.tsx
+++ b/Hdl21SchematicEditor/packages/EditorCore/src/panels.tsx
@@ -5,7 +5,7 @@
 //
 
 import * as React from "react";
-import { styled, useTheme } from "@mui/material/styles";
+import { styled, useTheme, createTheme } from "@mui/material/styles";
 import TextField from "@mui/material/TextField";
 import Drawer from "@mui/material/Drawer";
 import List from "@mui/material/List";
@@ -22,6 +22,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 
 // Local Imports
 import { theEditor } from "./editor";
+import { ThemeProvider } from "@emotion/react";
 
 // # Panels
 //
@@ -33,8 +34,17 @@ import { theEditor } from "./editor";
 export function Panels() {
   // Track the system-level color-theme preference via `useMediaQuery`.
   // Note the SchEditor has its own tracking of this.
-  // FIXME! actually react to this!
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
+
+  const theme = React.useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode: prefersDarkMode ? 'dark' : 'light',
+        },
+      }),
+    [prefersDarkMode],
+  );
 
   // Create the `Panels` react state, and give the parent `SchEditor` a way to update it.
   //
@@ -52,9 +62,11 @@ export function Panels() {
 
   // While this is called Panel*s* (plural), thus far there is only one, the right side, which gets all the props.
   return (
-    <React.Fragment>
-      <RightPanel {...state} />
-    </React.Fragment>
+    <ThemeProvider theme = {theme}>
+      <React.Fragment>
+        <RightPanel {...state} />
+      </React.Fragment>
+    </ThemeProvider>
   );
 }
 

--- a/readme.md
+++ b/readme.md
@@ -545,3 +545,4 @@ To dev-install the Python importer:
 - [PlatformInterface](./Hdl21SchematicEditor/packages/PlatformInterface/) defines the interface between `EditorCore` and its underlying "platforms", i.e. the other packages.
 - A web-based "platform" is also possible, [and is TBC](https://github.com/Vlsir/Hdl21Schematics/issues/10).
 - A command-line utility for schematic checking, exporting, schema migration, and the like is also possible, [and is TBC](https://github.com/Vlsir/Hdl21Schematics/issues/21).
+


### PR DESCRIPTION
This PR includes a 3 simple changes:

1. The `name` attribute in `package.json` is changed to allow builds in Ubuntu
2. `.github/test.yml` is tweaked to upload `.deb`, `.rpm` and `.exe` artifacts
3. A few lines in `panels.tsx` allows for a dark mode side panel.

All CI actions work on my fork and should be uploading all the artifacts.

Related issue: #18 